### PR TITLE
Remove unnecessary message() calls on configuration

### DIFF
--- a/standard/CombinedInstaller.cmake
+++ b/standard/CombinedInstaller.cmake
@@ -1,4 +1,4 @@
-# Utility for creating a combined installer for Windows
+## Utility for creating a combined installer for Windows
 #
 # This utility allows a WIX installer to be created with a single PACKAGE command,
 # and allows both 32 and 64 variants of the installer to be installed on a system
@@ -34,7 +34,9 @@ include(DefaultValue)
 include(ParseVersion)
 
 function(combined_installer)
-  message("Project name is ${CMAKE_PROJECT_NAME}")
+  if(COMBINED_INSTALLER_DEBUG)
+    message("Project name is ${CMAKE_PROJECT_NAME}")
+  endif()
 
   set(options )
   set(oneValueArgs NAME VENDOR CONTACT VERSION GUID LICENSE README WIXFILE)
@@ -97,7 +99,9 @@ function(combined_installer)
   #
   # For more information on the rationale for this process, see the discussion on semantic versioning
   # found at http://semver.org/
-  message("Upgrade GUID is ${ARG_GUID}")
+  if(COMBINED_INSTALLER_DEBUG)
+    message("Upgrade GUID is ${ARG_GUID}")
+  endif()
   set(CPACK_WIX_UPGRADE_GUID "{${ARG_GUID}}")
 
   # Need a custom wix installation template so that we update the CMake package registry correctly

--- a/standard/CombinedInstaller.cmake
+++ b/standard/CombinedInstaller.cmake
@@ -1,4 +1,4 @@
-## Utility for creating a combined installer for Windows
+# Utility for creating a combined installer for Windows
 #
 # This utility allows a WIX installer to be created with a single PACKAGE command,
 # and allows both 32 and 64 variants of the installer to be installed on a system


### PR DESCRIPTION
These printouts were happening on every call to `cmake`, for any projects using the standard CMake templates here. This is especially annoying if running `cmake`

Hide these under a debug flag rather than doing the usually-unhelpful printouts on every config.
