### PR TITLE
CMAKE_OSX_ARCHITECTURES must be set with FORCE

### DIFF
--- a/standard/StandardProject.cmake
+++ b/standard/StandardProject.cmake
@@ -39,10 +39,10 @@ function(standard_project_preinit)
   # project()
   if(APPLE)
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
-      set(CMAKE_OSX_ARCHITECTURES "arm" CACHE STRING "Mac OS X build architectures")
+      set(CMAKE_OSX_ARCHITECTURES "arm" CACHE STRING "Mac OS X build architectures" FORCE)
     else()
       # Build Fat binaries on OSX by default
-      set(CMAKE_OSX_ARCHITECTURES "x86_64;i386" CACHE STRING "Mac OS X build architectures")
+      set(CMAKE_OSX_ARCHITECTURES "x86_64;i386" CACHE STRING "Mac OS X build architectures" FORCE)
     endif()
   endif()
 

--- a/standard/StandardProject.cmake
+++ b/standard/StandardProject.cmake
@@ -37,7 +37,7 @@ endmacro()
 function(standard_project_preinit)
   # Pre-initialization steps - these variables must be set before the first call to
   # project()
-  if(APPLE)
+  if(APPLE AND CMAKE_OSX_ARCHITECTURES STREQUAL "")
     if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm")
       set(CMAKE_OSX_ARCHITECTURES "arm" CACHE STRING "Mac OS X build architectures" FORCE)
     else()


### PR DESCRIPTION
`CMAKE_OSX_ARCHITECTURES` is actually assigned on the command line, and if not there, is assigned by CMake to an empty string.  This means that it has a value when the `set` command is encountered, and therefore unless `FORCE` is also specified, the `set` will be ignored.

See #3 for more information.
