### PR TITLE
Fix install_headers()

### DIFF
--- a/standard/InstallHeaders.cmake
+++ b/standard/InstallHeaders.cmake
@@ -50,18 +50,20 @@ function(install_headers)
     # We find out what directory part the file is in, we want the shortest
     # relative path on the assumption that the file will be most properly
     # located in the directory whose relative address is the shortest.
-    file(RELATIVE_PATH src_rel ${CMAKE_SOURCE_DIR} ${src})
+    file(RELATIVE_PATH src_rel ${CMAKE_CURRENT_SOURCE_DIR} ${src})
     get_filename_component(src_rel ${src_rel} DIRECTORY)
-    string(LENGTH ${src_rel} src_rel_len)
-
-    file(RELATIVE_PATH bin_rel ${CMAKE_BINARY_DIR} ${src})
-    get_filename_component(bin_rel ${bin_rel} DIRECTORY)
-    string(LENGTH ${bin_rel} bin_rel_len)
-
-    if(src_rel_len LESS bin_rel_len)
+    if(src_rel)
+      string(LENGTH ${src_rel} src_rel_len)
       set(actual_rel ${src_rel})
-    else()
-      set(actual_rel ${bin_rel})
+    endif()
+
+    file(RELATIVE_PATH bin_rel ${CMAKE_CURRENT_BINARY_DIR} ${src})
+    get_filename_component(bin_rel ${bin_rel} DIRECTORY)
+    if(bin_rel)
+      string(LENGTH ${bin_rel} bin_rel_len)
+      if(src_rel AND bin_rel_len LESS src_rel_len)
+        set(actual_rel ${bin_rel})
+      endif()
     endif()
 
     get_filename_component(src_ext ${src} EXT)


### PR DESCRIPTION
PR #17 broke the install_headers() CMake function.

The bug is basically that it accidentally replaced `${CMAKE_CURRENT_SOURCE_DIR}` with `${CMAKE_SOURCE_DIR}`, which resulted in unexpectedly long paths like `autowiring-install-dir/src/autowiring/include/autowiring/autowiring.h`

This is the fix that I implemented and verified in the autowiring repo.
