### PR TITLE
Fix header installation logic

### DIFF
--- a/standard/InstallHeaders.cmake
+++ b/standard/InstallHeaders.cmake
@@ -40,31 +40,20 @@ function(install_headers)
       get_filename_component(src_bin ${src} ABSOLUTE BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
       if(EXISTS ${src_src})
         set(src ${src_src})
+        file(RELATIVE_PATH src_rel ${CMAKE_CURRENT_SOURCE_DIR} ${src})
+        get_filename_component(src_rel ${src_rel} DIRECTORY)
+        set(actual_rel ${src_rel})
       elseif(EXISTS ${src_bin})
         set(src ${src_bin})
+        file(RELATIVE_PATH bin_rel ${CMAKE_CURRENT_BINARY_DIR} ${src})
+        get_filename_component(bin_rel ${bin_rel} DIRECTORY)
+        set(actual_rel ${bin_rel})
       else()
         message(FATAL_ERROR "Could not find input header file ${src}")
       endif()
     endif()
 
-    # We find out what directory part the file is in, we want the shortest
-    # relative path on the assumption that the file will be most properly
-    # located in the directory whose relative address is the shortest.
-    file(RELATIVE_PATH src_rel ${CMAKE_CURRENT_SOURCE_DIR} ${src})
-    get_filename_component(src_rel ${src_rel} DIRECTORY)
-    if(src_rel)
-      string(LENGTH ${src_rel} src_rel_len)
-      set(actual_rel ${src_rel})
-    endif()
 
-    file(RELATIVE_PATH bin_rel ${CMAKE_CURRENT_BINARY_DIR} ${src})
-    get_filename_component(bin_rel ${bin_rel} DIRECTORY)
-    if(bin_rel)
-      string(LENGTH ${bin_rel} bin_rel_len)
-      if(src_rel AND bin_rel_len LESS src_rel_len)
-        set(actual_rel ${bin_rel})
-      endif()
-    endif()
 
     get_filename_component(src_ext ${src} EXT)
     install(

--- a/standard/InstallHeaders.cmake
+++ b/standard/InstallHeaders.cmake
@@ -33,32 +33,31 @@ function(install_headers)
       continue()
     endif()
 
-    # Need to make the path absolute.  We first look in the source directory,
-    # then we look in the binary directory, but only if the path is relative.
-    if(NOT IS_ABSOLUTE ${src})
-      get_filename_component(src_src ${src} ABSOLUTE BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-      get_filename_component(src_bin ${src} ABSOLUTE BASE_DIR ${CMAKE_CURRENT_BINARY_DIR})
-      if(EXISTS ${src_src})
-        set(src ${src_src})
-        file(RELATIVE_PATH src_rel ${CMAKE_CURRENT_SOURCE_DIR} ${src})
-        get_filename_component(src_rel ${src_rel} DIRECTORY)
-        set(actual_rel ${src_rel})
-      elseif(EXISTS ${src_bin})
-        set(src ${src_bin})
-        file(RELATIVE_PATH bin_rel ${CMAKE_CURRENT_BINARY_DIR} ${src})
-        get_filename_component(bin_rel ${bin_rel} DIRECTORY)
-        set(actual_rel ${bin_rel})
-      else()
-        message(FATAL_ERROR "Could not find input header file ${src}")
-      endif()
+    #When the path to the file is absolute, we don't know what we should be installing
+    #it relative to. Warn
+    if(IS_ABSOLUTE ${src})
+      message(WARNING "Not sure where to install file with absolute path ${src}")
+      continue()
     endif()
 
+    #Determine which path the file is relative to and use intermediate directories as the install path
+    foreach(_search_dir "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
+      get_filename_component(src_abs ${src} ABSOLUTE BASE_DIR ${_search_dir})
+      if(EXISTS ${src_abs})
+        set(src ${src_abs})
+        file(RELATIVE_PATH containing_dir ${_search_dir} ${src})
+        get_filename_component(containing_dir ${containing_dir} DIRECTORY)
+        break()
+      endif()
+    endforeach()
 
+    if(NOT EXISTS ${src_abs})
+      message(FATAL_ERROR "Could not find input header file ${src}")
+    endif()
 
-    get_filename_component(src_ext ${src} EXT)
     install(
       FILES ${src}
-      DESTINATION ${opt_DESTINATION}/${actual_rel}
+      DESTINATION ${opt_DESTINATION}/${containing_dir}
       ${opt_UNPARSED_ARGUMENTS}
     )
   endforeach()

--- a/standard/InstallHeaders.cmake
+++ b/standard/InstallHeaders.cmake
@@ -33,14 +33,14 @@ function(install_headers)
       continue()
     endif()
 
-    #When the path to the file is absolute, we don't know what we should be installing
-    #it relative to. Warn
+    # When the path to the file is absolute, we don't know what we should be installing
+    # it relative to. Warn
     if(IS_ABSOLUTE ${src})
       message(WARNING "Not sure where to install file with absolute path ${src}")
       continue()
     endif()
 
-    #Determine which path the file is relative to and use intermediate directories as the install path
+    # Determine which path the file is relative to and use intermediate directories as the install path
     foreach(_search_dir "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
       get_filename_component(src_abs ${src} ABSOLUTE BASE_DIR ${_search_dir})
       if(EXISTS ${src_abs})


### PR DESCRIPTION
The earlier code as is may pass Travis' `make install` step, but it revealed headers installed in strange paths including `../../build/src/autowiring` when platform tried to consume the result. Problems include a zero-length path being the shortest, making autowiring unusable by consumers.

We can instead remove the length comparisons altogether, since we know if we're installing a "src_src" or "bin_src".

I have verified this working for both an in-source and out-of-source build in the context of autowiring.
- [x] Verify the revised logic with `make install`
