### PR TITLE
Add -fno-omit-frame-pointer by default on RK1108

### DIFF
--- a/standard/toolchain-rk1108.cmake
+++ b/standard/toolchain-rk1108.cmake
@@ -5,7 +5,7 @@ set(BUILD_ARM 1)
 set(BUILD_RK1108 1)
 
 set(RK1108_TOOLCHAIN_ROOT /opt/rk1108_toolchain)
-set(RK1108_COMMON_FLAGS " --sysroot=${RK1108_TOOLCHAIN_ROOT}/usr/arm-rkcvr-linux-uclibcgnueabihf/sysroot -D__RK1108__")
+set(RK1108_COMMON_FLAGS " --sysroot=${RK1108_TOOLCHAIN_ROOT}/usr/arm-rkcvr-linux-uclibcgnueabihf/sysroot -D__RK1108__ -fno-omit-frame-pointer")
 
 set(CMAKE_C_COMPILER ${RK1108_TOOLCHAIN_ROOT}/usr/bin/arm-linux-gcc CACHE FILEPATH "C Compiler" FORCE)
 set(CMAKE_CXX_COMPILER ${RK1108_TOOLCHAIN_ROOT}/usr/bin/arm-linux-g++ CACHE FILEPATH "C++ Compiler" FORCE)


### PR DESCRIPTION
We need the frame pointer in order to catch exceptions on Rockchip devices. Necessary for downstream repositories such as Autowiring and LeapIPC which do throw informative exceptions.